### PR TITLE
[🚑️ Member] 에러 Resolve -->랜덤 닉네임 생성시 URL충돌

### DIFF
--- a/src/main/java/com/mulmeong/member/auth/dto/in/SignUpAndInRequestDto.java
+++ b/src/main/java/com/mulmeong/member/auth/dto/in/SignUpAndInRequestDto.java
@@ -6,6 +6,7 @@ import com.mulmeong.member.auth.util.RandomNicknameUtil;
 import com.mulmeong.member.auth.vo.in.SignUpAndSignInRequestVo;
 import com.mulmeong.member.common.exception.BaseException;
 import com.mulmeong.member.common.response.BaseResponseStatus;
+import org.springframework.beans.factory.annotation.Value;
 import lombok.*;
 
 import java.util.UUID;
@@ -19,6 +20,9 @@ public class SignUpAndInRequestDto {
     private String oauthId;
     private String oauthProvider;
     private String email;
+
+    @Value("${defaultProfileImage.url}")
+    private String defaultProfileImage;
 
     public static SignUpAndInRequestDto toDto(SignUpAndSignInRequestVo requestVo) {
 
@@ -41,7 +45,7 @@ public class SignUpAndInRequestDto {
                 .oauthProvider(oauthProvider)
                 .email(email)
                 .nickname(randomNicknameUtil.generateNickname()) // 랜덤 닉네임(경우의수 840억)
-                .profileImageUrl("image/198af19d-bbc6-4252-a632-d1a1ccd5c659.webp")
+                .profileImageUrl(defaultProfileImage)
                 .build();
     }
 

--- a/src/main/java/com/mulmeong/member/auth/util/RandomNicknameUtil.java
+++ b/src/main/java/com/mulmeong/member/auth/util/RandomNicknameUtil.java
@@ -13,7 +13,7 @@ public class RandomNicknameUtil {
         String fish = fishes[random.nextInt(fishes.length)];
         String randomCode = generateRandomCode();
 
-        return adjective + fish + "#" + randomCode;
+        return adjective + fish + "-" + randomCode;
     }
 
     private String generateRandomCode() {


### PR DESCRIPTION
### 📅 2024.12.09

### 🌵 Branch
hotfix/#31 → develop

### 📢 Description
현재 랜덤 닉네임 생성시 형용사 + 명사 + "#" + {code}는 브라우저 URL 에서 fragment identifier '#' 과 충돌

--　--　--　--　--　--　--　--　--　--　--　--　🚑️

### 💬 Issue Number
- #31 

### 🔖 Note
